### PR TITLE
Adding missing strategy to LocalEnsemble and some bug fixes

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,11 @@
+=== 0.12.0 / 2014-08-14
+
+* Adding proportional missing strategy to ensembles
+* Fixing bug: local predictions did not round float values when given as
+  integers and that generated mismatches in predictions
+* Fixing bug: Error for regression models with proportional missing strategy
+  were not returned for 1-instance nodes
+
 === 0.11.2 / 2014-07-23
 
 * Adding the ability to build a local model from a JSON file containing the

--- a/docs/index.md
+++ b/docs/index.md
@@ -824,7 +824,7 @@ structure by setting the path to the file as first parameter:
                        function(error, prediction) {console.log(prediction)});
 ```
 
-Predictions Missing Strategy
+Predictions' Missing Strategy
 ----------------------------
 
 There are two different strategies when dealing with missing values
@@ -889,7 +889,21 @@ combination method:
     Otherwise, the prediction is plurality for the rest of predicted
     values.
 
-An example of `threshold` combination method would be:
+An there's an optional third argument named `options` that specify some
+additional configuration values, such as the missing strategy used in each
+model's prediction:
+
+```js
+    var bigml = require('bigml');
+    var localEnsemble = new bigml.LocalEnsemble('ensemble/51901f4337203f3a9a000215');
+    localEnsemble.predict({'petal length': 1}, 0, {missingStrategy: 1},
+                          function(error, prediction) {console.log(prediction)});
+```
+in this case the proportional missing strategy (default would be last
+prediction missing strategy) will be applied.
+
+Another example would be the `threshold` combination method, where the third
+argument contains the `threshold` and `category` values used in the algorithm:
 
 ```js
     var bigml = require('bigml');

--- a/lib/LocalCluster.js
+++ b/lib/LocalCluster.js
@@ -20,9 +20,9 @@ var PATH = (NODEJS) ? "./" : "";
 if (NODEJS) {
     var util = require('util');
     var events = require('events');
+    var Cluster = require(PATH + 'Cluster');
 }
 var utils = require(PATH + 'utils');
-var Cluster = require(PATH + 'Cluster');
 var LocalCentroid = require(PATH + 'LocalCentroid');
 var constants = require(PATH + 'constants');
 
@@ -40,6 +40,9 @@ function parseTerms(text, caseSensitive) {
   }
   pattern = new RegExp('(\\b|_)([^\\b_\\s]+?)(\\b|_)', 'g');
   matches = text.match(pattern);
+  if (matches == null) {
+    return [];
+  }
   matchesLen = matches.length;
   if (!caseSensitive) {
     for (i = 0; i < matchesLen; i++) {
@@ -114,7 +117,7 @@ function LocalCluster(resource, connection) {
   self = this;
   fillStructure = function (error, resource) {
     /**
-     * Auxiliary function to load the resource info in the Model structure.
+     * Auxiliary function to load the resource info in the Cluster structure.
      *
      * @param {object} error Error info
      * @param {object} resource Model's resource info

--- a/lib/LocalEnsemble.js
+++ b/lib/LocalEnsemble.js
@@ -65,6 +65,7 @@ function LocalEnsemble(ensembleOrModels, connection, maxModels) {
   }
 
   this.modelsSplits = [];
+  this.predictionsOfModels = [];
   this.ready = undefined;
 
   self = this;
@@ -212,6 +213,7 @@ LocalEnsemble.prototype.predict = function (inputData, method, options, cb) {
    */
 
   var index, len, splitIndex, splitLen, predictions, votes, model,
+    missingStrategy,
     issuePrediction, self = this;
   predictions = [];
   len = this.modelsSplits.length;
@@ -231,18 +233,24 @@ LocalEnsemble.prototype.predict = function (inputData, method, options, cb) {
   };
 
   if (this.ready) {
+    if ((typeof options !== 'undefined') && ('missingStrategy' in options)) {
+        missingStrategy = options.missingStrategy;
+    } else {
+        missingStrategy = constants.LAST_PREDICTION;
+    } 
     for (index = 0; index < len; index++) {
       splitLen = this.modelsSplits[index].length;
       for (splitIndex = 0; splitIndex < splitLen; splitIndex++) {
         model = this.modelsSplits[index][splitIndex];
         var data = (JSON.parse(JSON.stringify(inputData)));
         if (cb) {
-          model.predict(data, issuePrediction);
+          model.predict(data, missingStrategy, issuePrediction);
         } else {
-          predictions.push(model.predict(data));
+          predictions.push(model.predict(data, missingStrategy));
         }
       }
     }
+    this.predictionsOfModels = predictions;
     if (!cb) {
       votes = new MultiVote(predictions);
       return votes.combine(method, options);

--- a/lib/LocalModel.js
+++ b/lib/LocalModel.js
@@ -166,7 +166,6 @@ LocalModel.prototype.predict = function (inputData, missingStrategy, cb) {
    * @param {function} cb Callback
    */
   var newInputData = {}, field, prediction, self = this;
-
   if (arguments.length < 3 && (typeof missingStrategy === 'function')) {
     // downgrading gently to old syntax with no missingStrategy
     return self.predict(inputData, undefined, missingStrategy);

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -321,10 +321,15 @@ Tree.prototype.predict = function (inputData, path, missingStrategy) {
       for (element = 0; element < distribution.length; element++) {
         totalInstances += distribution[element][1];
       }
-      confidence = regressionError(
-        unbiasedSampleVariance(distribution, prediction),
-        totalInstances
-      );
+      if (totalInstances > 1) {
+        confidence = regressionError(
+          unbiasedSampleVariance(distribution, prediction),
+          totalInstances
+        );
+      } else {
+        var lPredict = this.predict(inputData, null, constants.LAST_PREDICTION);
+        confidence = lPredict.confidence;
+      } 
       return {
         'prediction': prediction,
         'path': path,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -449,6 +449,7 @@ exports = {
      * @param {object} fields Model's fields collection
      */
     var field, value, type;
+    var integerDataTypes = ['int8', 'int16', 'int32', 'int64', 'year', 'month', 'day', 'day-of-week', 'day-of-month', 'minute', 'second', 'milisecond'];
     for (field in inputData) {
       if (inputData.hasOwnProperty(field)) {
         if ((fields[field].optype === 'numeric' &&
@@ -467,6 +468,11 @@ exports = {
                             fields[field].name + 'for value ' +
                             inputData[field]);
           }
+        }
+        // round the value for fields that should be integers
+        if ((integerDataTypes.indexOf(fields[field].datatype) >= 0) &&
+            (inputData[field] % 1 !== 0)){
+          inputData[field] = Math.round(inputData[field]);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bindings",
     "BigML"
   ],
-  "version": "0.11.2",
+  "version": "0.12.0",
   "author": {
     "name": "BigML",
     "email": "info@bigml.com"

--- a/test/LocalEnsemble-test.js
+++ b/test/LocalEnsemble-test.js
@@ -7,7 +7,7 @@ describe('Manage local ensemble objects', function () {
     ensembleId, ensemble = new bigml.Ensemble(), ensembleResource,
     prediction = new bigml.Prediction(), inputData = {'petal width': 0.5}, method = 1,
     ensembleFinishedResource, modelsList, index, model = new bigml.Model(), reference,
-    localEnsemble, len, finishedModelsList = [];
+    localEnsemble, len, finishedModelsList = [], missingStrategy = 1;
 
   before(function (done) {
     source.create(path, undefined, function (error, data) {
@@ -33,7 +33,10 @@ describe('Manage local ensemble objects', function () {
             function retrieveModel(error, data) {
               finishedModelsList.push(data);
               if (finishedModelsList.length === len) {
-                prediction.create(ensembleId, inputData, {combiner: method}, retrievePrediction);
+                prediction.create(ensembleId, inputData,
+                                  {combiner: method,
+                                   'missing_strategy': missingStrategy},
+                                  retrievePrediction);
               }
             }
             for (index = 0; index < len; index++) {
@@ -60,15 +63,17 @@ describe('Manage local ensemble objects', function () {
   });
   describe('#predict(inputData, method, callback)', function () {
     it('should predict asynchronously from input data', function (done) {
-      localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(data.prediction, reference);
-        done();
+      localEnsemble.predict(inputData, method, {missingStrategy: missingStrategy},
+        function (error, data) {
+          assert.equal(data.prediction, reference);
+          done();
       });
     });
   });
   describe('#predict(inputData, method)', function () {
     it('should predict synchronously from input data', function () {
-      var result = localEnsemble.predict(inputData, method);
+      var result = localEnsemble.predict(inputData, method,
+        {missingStrategy: missingStrategy});
       assert.equal(result.prediction, reference);
     });
   });
@@ -87,9 +92,10 @@ describe('Manage local ensemble objects', function () {
   });
   describe('#predict(inputData, method, callback)', function () {
     it('should predict asynchronously from input data', function (done) {
-      localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(data.prediction, reference);
-        done();
+      localEnsemble.predict(inputData, method, {missingStrategy: missingStrategy},
+        function (error, data) {
+          assert.equal(data.prediction, reference);
+          done();
       });
     });
   });
@@ -108,9 +114,10 @@ describe('Manage local ensemble objects', function () {
   });
   describe('#predict(inputData, method)', function () {
     it('should predict asynchronously from input data', function (done) {
-      localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(data.prediction, reference);
-        done();
+      localEnsemble.predict(inputData, method, {missingStrategy: missingStrategy},
+        function (error, data) {
+          assert.equal(data.prediction, reference);
+          done();
       });
     });
   });
@@ -122,7 +129,7 @@ describe('Manage local ensemble objects', function () {
   });
   describe('#predict(inputData, method)', function () {
     it('should predict synchronously from input data', function () {
-      var result = localEnsemble.predict(inputData, method);
+      var result = localEnsemble.predict(inputData, method, {missingStrategy: missingStrategy});
       assert.equal(result.prediction, reference);
     });
   });


### PR DESCRIPTION
- Adding proportional missing strategy to ensembles
- Fixing bug: local predictions did not round float values when given as
  integers and that generated mismatches in predictions
- Fixing bug: Error for regression models with proportional missing
  strategy were not returned for 1-instance nodes
