### PR TITLE
removed behavior in which all uncaught exceptions were silently ignored

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -63,7 +63,7 @@ if (NODEJS) {
   // 4 - console and file with debug info
   var LOG_LEVELS = ['0', '1', '2', '3', '4'];
 
-  define("BIGML_LOG_FILE", process.env.BIGML_LOG_FILE || 'bigml.log');
+  define("BIGML_LOG_FILE", process.env.BIGML_LOG_FILE);
   if ((typeof process.env.BIGML_LOG_LEVEL) === 'undefined' ||
        LOG_LEVELS.indexOf(process.env.BIGML_LOG_LEVEL) < 0) {
     define("BIGML_LOG_LEVEL", 1);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,14 +22,23 @@ var CONSOLE_SILENT = (['0', '3'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
 var FILE_SILENT = (['0', '2'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
 var LEVEL = (['4'].indexOf(constants.BIGML_LOG_LEVEL) > -1) ? 'debug' : 'error';
 
-var logger = new (winston.Logger)({
-  exitOnError: false,
-  transports: [
-    new winston.transports.Console({silent: CONSOLE_SILENT, level: LEVEL}),
+var exitOnError = false;
+var transports = [
+  new winston.transports.Console({silent: CONSOLE_SILENT, level: LEVEL})
+];
+
+if (constants.BIGML_LOG_FILE) {
+  exitOnError = true;
+  transports.push(
     new winston.transports.File({filename: constants.BIGML_LOG_FILE,
                                  handleExceptions: true,
                                  silent: FILE_SILENT, level: LEVEL})
-  ]
+  );
+}
+
+var logger = new (winston.Logger)({
+  exitOnError: exitOnError,
+  transports: transports
 });
 
 module.exports = logger;


### PR DESCRIPTION
``` javascript
var bigml = require('bigml');

throw new Error('oh no');
```

Expected: `Error: oh no` followed by stack trace
Actual: no output

༼っ ༎ຶ ෴ ༎ຶ༽っ ︵ ┻┻
