### PR TITLE
Simple workaround for FormData limitation

### DIFF
--- a/lib/Source.js
+++ b/lib/Source.js
@@ -83,7 +83,11 @@ Source.prototype.create = function (path, args, retry, cb) {
   }
   for (arg in options.args) {
     if (options.args.hasOwnProperty(arg)) {
-      form.append(arg, options.args[arg]);
+      if (typeof options.args[arg] == 'object') {
+        form.append(arg, JSON.stringify(options.args[arg]));
+      } else {
+        form.append(arg, options.args[arg]);
+      }
     }
   }
   form.getLength(function (error, length) {

--- a/test/Source-test-res.js
+++ b/test/Source-test-res.js
@@ -21,9 +21,20 @@ var scriptName = path.basename(__filename);
 
 describe(scriptName + ': Manage source objects', function () {
   var sourceId, source = new bigml.Source(), path = './data/iris.csv';
+  var tagsAsList = ['tag1', 'tag2'];
+  var tagsAsString = "['tag1', 'tag2']";
   describe('#create(path, args, callback)', function () {
-    it('should create a source from a file', function (done) {
-      source.create(path, undefined, function (error, data) {
+    it('should create a source from a file, stringified tags', function (done) {
+      source.create(path, { tags: tagsAsString }, function (error, data) {
+        assert.equal(data.code, bigml.constants.HTTP_CREATED);
+        sourceId = data.resource;
+        done();
+      });
+    });
+  });
+  describe('#create(path, args, callback)', function () {
+    it('should create a source from a file, array of tags', function (done) {
+      source.create(path, { tags: tagsAsList }, function (error, data) {
         assert.equal(data.code, bigml.constants.HTTP_CREATED);
         sourceId = data.resource;
         done();


### PR DESCRIPTION
The Form-data module used to create Sources when uploading a csv file does not allow to pass arrays or dicts as Form fields. For example, when specifying a set of tags, you need to pass a string encoding the tags as an array (i.e., "['tag1', 'tag2', 'tag3'...]"). This is not a problem in itself but differs from the way you would pass those same tags to create any other resources (which happily accept an array encoding your list of tags).

So, to improve the API consistency, I suggest to introduce the workaround in this PR, which simply checks when an 'object' is passed as one of the creation arguments and stringifies it before adding it to the form.

Please, also notice that if you pass an 'object' creation argument when creating a source from a CSV file, the current code will just fail.