### PR TITLE
Upgrading dependencies to avoid warnings

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.16.0 / 2018-03-01
+
+* Upgrading versions of dependencies and adapting to their changes.
+
 === 1.15.1 / 2018-02-23
 
 * Fixing bug in local model and ensemble predictions for regressions in

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -202,9 +202,9 @@ function regressionError(distVariance, population, zeta) {
   }
 
   if (population > 0) {
-    var error, jDollar = (NODEJS) ? jStat.j$ : j$,
-      chiDistr = jDollar.chisquare(population),
-      ppf = chiDistr.inv(1 - jDollar.erf(zeta / Math.sqrt(2)));
+    var error, jStats = (NODEJS) ? jStat : j$,
+      chiDistr = jStats.chisquare(population),
+      ppf = chiDistr.inv(1 - jStats.erf(zeta / Math.sqrt(2)));
     if (ppf !== 0) {
       error = distVariance * (population - 1) / ppf;
       error = error * Math.pow((Math.sqrt(population) + zeta), 2);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bindings",
     "BigML"
   ],
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "BigML",
     "email": "info@bigml.com"
@@ -21,17 +21,17 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "async": "^0.2.10",
-    "combined-stream": "0.0.4",
-    "fast-csv": "1.0.0",
-    "form-data": "0.0.10",
-    "jStat": "0.0.2",
+    "async": "2.6.0",
+    "combined-stream": "1.0.6",
+    "fast-csv": "2.4.1",
+    "form-data": "2.3.2",
+    "jStat": "1.7.1",
     "mersenne-twister": "1.1.0",
-    "mime": "1.2.2",
+    "mime": "2.2.0",
     "numjs": "0.15.1",
-    "request": "2.40.0",
+    "request": "2.83.0",
     "snowball": "0.3.1",
-    "winston": "0.7.1"
+    "winston": "2.4.0"
   },
   "scripts": {
     "test": "mocha -t 200000"

--- a/test/Dataset-test-res.js
+++ b/test/Dataset-test-res.js
@@ -110,9 +110,8 @@ describe(scriptName + ': Manage dataset objects', function () {
         if (error == null) {
           fs.readFile(filename, "utf8", function (error2, dataf) {
             assert.equal(dataf, datap);
-            dataset.delete(datasetId, function (error3, data2) {
-              assert.equal(error3, null);
-              fs.unlink(filename);
+            fs.unlink(filename, function (error, data) {
+              assert.equal(error, null);
               done();
             });
           });
@@ -120,12 +119,13 @@ describe(scriptName + ': Manage dataset objects', function () {
       });
     });
   });
-  describe('#delete(dataset, callback)', function () {
-    it('should delete the remote dataset', function (done) {
-      dataset.delete(datasetId2, function (error, data) {
-        assert.equal(error, null);
-        dataset.delete(datasetId3, function (error, data) {
-          assert.equal(error, null);
+  after(function (done) {
+    dataset.delete(datasetId3, function (error, data) {
+      assert.equal(error, null);
+      dataset.delete(datasetId2, function (error2, data2) {
+        assert.equal(error2, null);
+        dataset.delete(datasetId, function (error3, data3) {
+          assert.equal(error3, null);
           done();
         });
       });


### PR DESCRIPTION
Upgrading versions in dependencies.  In issue #113 we were warned about some jStat vulnerabilities that have been corrected in the latest version. Thanks for the heads up. We've revisited the rest of dependencies versions as well. 