### PR TITLE
Zapier-related Changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,30 @@
 // This will allow us to know we are running under node
 process.RUNNING_IN_NODEJS = 'true';
 
+if (process.env.BIGML_REQUIRE_PRELOAD &&
+   process.env.BIGML_REQUIRE_PRELOAD != "false" &&
+   process.env.BIGML_REQUIRE_PRELOAD != "no") {
+  require('./lib/sharedProtos');
+  require('./lib/LocalAnomaly');
+  require('./lib/LocalAssociation');
+  require('./lib/LocalCentroid');
+  require('./lib/LocalModel');
+  require('./lib/AnomalyTree');
+  require('./lib/AssociationRule');
+  require('./lib/Item');
+  require('./lib/Tree');
+  require('./lib/BoostedTree');
+  require('./lib/Predicates');
+  require('./lib/Predicate');
+  require('./lib/MultiVote');
+  require('./lib/MultiVote');
+  require('./lib/MultiVoteList');
+  require('./lib/tssubmodels');
+  require('./lib/math_ops');
+  require('jStat');
+  require('cwise');
+}
+
 module.exports = {
   // Common modules: connection, REST common interface, utilities and constants
   BigML: require('./lib/BigML'),

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@
  * under the License.
  */
 
+// This will allow us to know we are running under node
+process.RUNNING_IN_NODEJS = 'true';
+
 module.exports = {
   // Common modules: connection, REST common interface, utilities and constants
   BigML: require('./lib/BigML'),

--- a/lib/AnomalyTree.js
+++ b/lib/AnomalyTree.js
@@ -16,7 +16,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var Predicates = require(PATH + 'Predicates');

--- a/lib/AssociationRule.js
+++ b/lib/AssociationRule.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/BoostedTree.js
+++ b/lib/BoostedTree.js
@@ -23,8 +23,8 @@ var TEXT_TYPES = ["text", "items"];
 var constants = require(PATH + 'constants');
 var Predicate = require(PATH + 'Predicate');
 var utils = require(PATH + 'utils');
-var jStat = NODEJS ? require('jStat') : require('jstat.min.js');
-
+var JSTAT_EXT = NODEJS ? "" : ".min.js"; 
+var jStat = require('jStat' + JSTAT_EXT);
 
 function splitField(children) {
   /**

--- a/lib/BoostedTree.js
+++ b/lib/BoostedTree.js
@@ -16,7 +16,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = NODEJS ? "./" : "";
 var TEXT_TYPES = ["text", "items"];
 

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/LocalAnomaly.js
+++ b/lib/LocalAnomaly.js
@@ -14,7 +14,7 @@
  * under the License.
  */
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 var TEXT_TYPES = ["categorical", "text", "datetime"];
 

--- a/lib/LocalAssociation.js
+++ b/lib/LocalAssociation.js
@@ -14,7 +14,8 @@
  * under the License.
  */
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 if (NODEJS) {

--- a/lib/LocalCentroid.js
+++ b/lib/LocalCentroid.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/LocalCluster.js
+++ b/lib/LocalCluster.js
@@ -14,7 +14,7 @@
  * under the License.
  */
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 if (NODEJS) {

--- a/lib/LocalDeepnet.js
+++ b/lib/LocalDeepnet.js
@@ -15,7 +15,7 @@
  */
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/LocalEnsemble.js
+++ b/lib/LocalEnsemble.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var LocalModel = require(PATH + 'LocalModel');

--- a/lib/LocalLogisticRegression.js
+++ b/lib/LocalLogisticRegression.js
@@ -15,7 +15,7 @@
  */
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/LocalModel.js
+++ b/lib/LocalModel.js
@@ -15,7 +15,7 @@
  */
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = NODEJS ? "./" : "";
 var MODEL_OPERATING_KINDS = ["probability", "confidence"];
 

--- a/lib/LocalTimeSeries.js
+++ b/lib/LocalTimeSeries.js
@@ -15,7 +15,7 @@
  */
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var REQUIRED_INPUT = "horizon";

--- a/lib/LocalTopicModel.js
+++ b/lib/LocalTopicModel.js
@@ -14,7 +14,7 @@
  * under the License.
  */
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var QUOTE_CODE = 39;

--- a/lib/MultiVote.js
+++ b/lib/MultiVote.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var constants = require(PATH + 'constants');

--- a/lib/MultiVoteList.js
+++ b/lib/MultiVoteList.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var constants = require(PATH + 'constants');

--- a/lib/Predicate.js
+++ b/lib/Predicate.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var utils = require(PATH + 'utils');

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -83,7 +83,11 @@ Source.prototype.create = function (path, args, retry, cb) {
   }
   for (arg in options.args) {
     if (options.args.hasOwnProperty(arg)) {
-      form.append(arg, options.args[arg]);
+      if (typeof options.args[arg] == 'object') {
+        form.append(arg, JSON.stringify(options.args[arg]));
+      } else {
+        form.append(arg, options.args[arg]);
+      }
     }
   }
   form.getLength(function (error, length) {

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -23,8 +23,8 @@ var TEXT_TYPES = ["text", "items"];
 var constants = require(PATH + 'constants');
 var Predicate = require(PATH + 'Predicate');
 var utils = require(PATH + 'utils');
-var jStat = (NODEJS) ? require('jStat') : require('jstat.min.js');
-
+var JSTAT_EXT = NODEJS ? "" : ".min.js"; 
+var jStat = require('jStat' + JSTAT_EXT);
 
 var PRECISION = 5;
 

--- a/lib/Tree.js
+++ b/lib/Tree.js
@@ -16,7 +16,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 var TEXT_TYPES = ["text", "items"];
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -16,10 +16,10 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 
 exports = {};
-
+exports.NODEJS = false;
 
 function define(name, value) {
   Object.defineProperty(exports, name, {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,21 +15,34 @@
 
 "use strict";
 
-var winston = require('winston');
-var constants = require('./constants');
+var ZAP = process.env.BIGML_REQUIRE_PRELOAD &&
+    process.env.BIGML_REQUIRE_PRELOAD != "false" &&
+    process.env.BIGML_REQUIRE_PRELOAD != "no";
 
-var CONSOLE_SILENT = (['0', '3'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
-var FILE_SILENT = (['0', '2'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
-var LEVEL = (['4'].indexOf(constants.BIGML_LOG_LEVEL) > -1) ? 'debug' : 'error';
+if (ZAP) {
+  module.exports = {
+    error : function(){},
+    debug : function(){},
+    warning : function(){},
+  };
+} else {
 
-var logger = new (winston.Logger)({
-  exitOnError: false,
-  transports: [
-    new winston.transports.Console({silent: CONSOLE_SILENT, level: LEVEL}),
-    new winston.transports.File({filename: constants.BIGML_LOG_FILE,
-                                 handleExceptions: true,
-                                 silent: FILE_SILENT, level: LEVEL})
-  ]
-});
+  var winston = require('winston');
+  var constants = require('./constants');
+  
+  var CONSOLE_SILENT = (['0', '3'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
+  var FILE_SILENT = (['0', '2'].indexOf(constants.BIGML_LOG_LEVEL) > -1);
+  var LEVEL = (['4'].indexOf(constants.BIGML_LOG_LEVEL) > -1) ? 'debug' : 'error';
+  
+  var logger = new (winston.Logger)({
+    exitOnError: false,
+    transports: [
+      new winston.transports.Console({silent: CONSOLE_SILENT, level: LEVEL}),
+      new winston.transports.File({filename: constants.BIGML_LOG_FILE,
+                                   handleExceptions: true,
+                                   silent: FILE_SILENT, level: LEVEL})
+    ]
+  });
+  module.exports = logger;
+}
 
-module.exports = logger;

--- a/lib/math_ops.js
+++ b/lib/math_ops.js
@@ -16,7 +16,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var constants = require(PATH + 'constants');

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -20,7 +20,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var constants = require(PATH + 'constants');

--- a/lib/sharedProtos.js
+++ b/lib/sharedProtos.js
@@ -15,7 +15,7 @@
  */
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = NODEJS ? "./" : "";
 var utils = require(PATH + 'utils');
 var constants = require(PATH + 'constants');

--- a/lib/tssubmodels.js
+++ b/lib/tssubmodels.js
@@ -23,16 +23,10 @@
  */
 
 "use strict";
-
-
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
-
-
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var OPERATORS = {"A": function(x, s) {return x + s;},
                  "M": function(x, s) {return x * s;},
                  "N": function(x, s) {return x;}};
-
-
 
 function seasonContribution(s, h) {
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@
 
 "use strict";
 
-var NODEJS = ((typeof module !== 'undefined') && module.exports);
+var NODEJS =  process && process.RUNNING_IN_NODEJS === 'true';
 var PATH = (NODEJS) ? "./" : "";
 
 var constants = require(PATH + 'constants');

--- a/test/Script-test-res.js
+++ b/test/Script-test-res.js
@@ -21,13 +21,15 @@ var scriptName = path.basename(__filename);
 
 describe(scriptName + ': Manage whizzml script objects', function () {
   var scriptId, script = new bigml.Script(), sourceCode = '(+ 1 1)';
+  var tagsAsList = ['tag1', 'tag2'];
   describe('#create(sourceCode, args, callback)', function () {
-    it('should create a script from a excerpt of code', function (done) {
-      script.create(sourceCode, undefined, function (error, data) {
-        assert.equal(data.code, bigml.constants.HTTP_CREATED);
-        scriptId = data.resource;
-        done();
-      });
+    it('should create a script from a excerpt of code, array of tags',
+       function (done) {
+         script.create(sourceCode, { tags: tagsAsList }, function (error, data) {
+           assert.equal(data.code, bigml.constants.HTTP_CREATED);
+           scriptId = data.resource;
+           done();
+         });
     });
   });
   describe('#get(script, finished, query, callback)', function () {

--- a/test/Source-test-res.js
+++ b/test/Source-test-res.js
@@ -21,9 +21,20 @@ var scriptName = path.basename(__filename);
 
 describe(scriptName + ': Manage source objects', function () {
   var sourceId, source = new bigml.Source(), path = './data/iris.csv';
+  var tagsAsList = ['tag1', 'tag2'];
+  var tagsAsString = "['tag1', 'tag2']";
   describe('#create(path, args, callback)', function () {
-    it('should create a source from a file', function (done) {
-      source.create(path, undefined, function (error, data) {
+    it('should create a source from a file, stringified tags', function (done) {
+      source.create(path, { tags: tagsAsString }, function (error, data) {
+        assert.equal(data.code, bigml.constants.HTTP_CREATED);
+        sourceId = data.resource;
+        done();
+      });
+    });
+  });
+  describe('#create(path, args, callback)', function () {
+    it('should create a source from a file, array of tags', function (done) {
+      source.create(path, { tags: tagsAsList }, function (error, data) {
         assert.equal(data.code, bigml.constants.HTTP_CREATED);
         sourceId = data.resource;
         done();


### PR DESCRIPTION
This PR brings in changes required to make bigml-node Zapier-friendly.

To identify when the JS code is running under Node.js, as opposed to running in a Web browser, the `index.js` file now defines a `process.RUNNING_IN_NODEJS` global which is then checked wherever needed.

Additionally, a number of files rely on the `BIGML_REQUIRE_PRELOAD` environment variable to be set to ensure proper integration with Zapier. When `BIGML_REQUIRE_PRELOAD` is set -- both at the time when a Zapier app is built and when it is run on Zapier's platofrm -- the bigml-node bahavior is slightly modified to include preloading of some `require`d files, `logger.js` override, and other minor stuff.

Preloading is required to make some bigml-node features work seamlessly with Zapier's mechanism to identify dependencies and bundle them together.