### PR TITLE
fix regression deepnet predict bug found in predict server

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.18.6 / 2019-03-19
+
+* Fixing bug in local deepnet regression predictions.
+
 === 1.18.5 / 2019-03-14
 
 * Fixing bug in local ensemble with more than 200 models.

--- a/lib/LocalDeepnet.js
+++ b/lib/LocalDeepnet.js
@@ -480,14 +480,19 @@ LocalDeepnet.prototype.fillArray = function(inputData, uniqueTerms) {
       }
       columns.push(category);
     } else {
-      columns.push(inputData[fieldId]);
       // when missing_numerics is True and the field had missings
       // in the training data, then we add a new "is missing?" element
       // whose value is 1 or 0 according to whether the field is
       // missing or not in the input data
       if (this.missingNumerics &&
           this.fields[fieldId].summary['missing_count'] > 0) {
-        columns.push(inputData.hasOwnProperty(fieldId) ? 0 : 1);
+        if (inputData.hasOwnProperty(fieldId)) {
+          columns = columns.concat([inputData[fieldId], 0.0]);
+        } else {
+          columns = columns.concat([0.0, 1.0]);
+        }
+      } else {
+        columns.push(inputData[fieldId])
       }
     }
   }
@@ -569,6 +574,7 @@ LocalDeepnet.prototype.modelPredict = function (inputArray, model) {
   var layers, yOut, yStats;
   layers = net.initLayers(model.layers);
   yOut = net.propagate(inputArray, layers);
+
   if (this.regression) {
     yStats = moments(model['output_exposition']);
     yOut = net.destandardize(yOut, yStats);

--- a/lib/mathOps.js
+++ b/lib/mathOps.js
@@ -263,18 +263,16 @@ net.propagate = function (xIn, layers) {
 };
 
 net.sumAndNormalize = function(youts, isRegression) {
-
+  var ysums = [], outDist = [], index, row, len, sumRow, index2, len2,
+      isRegression, ysum, rowSum, index3, len3, newRow, yout, sum, norm;
   if (isRegression) {
-    var norm = youts.length;
-    var ysum = 0;
+    norm = youts.length;
+    ysum = 0;
     for (index = 0, len = norm; index < len; index++) {
       ysum += youts[index];
-      outDist.push([ysum[0] / norm]);    }
-    return ysum / norm;
+    }
+    return ysum / (0.0 + norm);
   } else {
-
-    var ysums = [], outDist = [], index, row, len, sumRow, index2, len2,
-        isRegression, ysum, rowSum, index3, len3, newRow, yout, sum, norm;
     for (index = 0, len = youts[0].length; index < len; index++) {
       sumRow = [];
       row = youts[0][index];

--- a/lib/mathOps.js
+++ b/lib/mathOps.js
@@ -263,30 +263,32 @@ net.propagate = function (xIn, layers) {
 };
 
 net.sumAndNormalize = function(youts, isRegression) {
-  var ysums = [], index, row, len, sumRow, index2, len2, outDist = [],
-    isRegression, ysum, rowSum, index3, len3, newRow, yout, sum, norm;
-  for (index = 0, len = youts[0].length; index < len; index++) {
-    sumRow = [];
-    row = youts[0][index];
-    for (index2 = 0, len2 = row.length; index2 < len2; index2++) {
-      sum = 0.0;
-      for (index3 = 0, len3 = youts.length; index3 < len3; index3++) {
-        yout = youts[index3];
-        sum += yout[index][index2];
-      }
-      sumRow.push(sum);
-    }
-    ysums.push(sumRow);
-  }
 
-  outDist = [];
   if (isRegression) {
-    for (index = 0, len = ysums.length; index < len; index++) {
-      ysum = ysums[index];
-      norm = ysums.length;
-      outDist.push([ysum[0] / norm]);
-    }
+    var norm = youts.length;
+    var ysum = 0;
+    for (index = 0, len = norm; index < len; index++) {
+      ysum += youts[index];
+      outDist.push([ysum[0] / norm]);    }
+    return ysum / norm;
   } else {
+
+    var ysums = [], outDist = [], index, row, len, sumRow, index2, len2,
+        isRegression, ysum, rowSum, index3, len3, newRow, yout, sum, norm;
+    for (index = 0, len = youts[0].length; index < len; index++) {
+      sumRow = [];
+      row = youts[0][index];
+      for (index2 = 0, len2 = row.length; index2 < len2; index2++) {
+        sum = 0.0;
+        for (index3 = 0, len3 = youts.length; index3 < len3; index3++) {
+          yout = youts[index3];
+          sum += yout[index][index2];
+        }
+        sumRow.push(sum);
+      }
+      ysums.push(sumRow);
+    }
+
     for (index = 0, len = ysums.length; index < len; index++) {
       ysum = ysums[index];
       rowSum = ysum.reduce(function(a, b) { return a + b; }, 0.0);
@@ -298,6 +300,7 @@ net.sumAndNormalize = function(youts, isRegression) {
   }
   return outDist;
 }
+
 
 if (NODEJS) {
   module.exports = net;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bindings",
     "BigML"
   ],
-  "version": "1.18.5",
+  "version": "1.18.6",
   "author": {
     "name": "BigML",
     "email": "info@bigml.com"


### PR DESCRIPTION
The bug was found in mathOps/sumAndNormalize. Fixed by comparing it with Python's implementation of the same function.