### PR TITLE
Wrap regression deepnet local prediction in dictionary + fix bug when using addUnusedFields

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,8 @@
+=== 1.18.7 / 2019-03-23
+
+* Fixing bug in local deepnet regression predictions (prediction not wrapped
+in dictionary + crash when using addUnusedFields).
+
 === 1.18.6 / 2019-03-19
 
 * Fixing bug in local deepnet regression predictions.

--- a/lib/LocalDeepnet.js
+++ b/lib/LocalDeepnet.js
@@ -516,8 +516,9 @@ LocalDeepnet.prototype.deepnetPredict = function (inputData) {
   inputArray = this.fillArray(inputData, uniqueTerms);
   if (typeof this.networks !== 'undefined') {
     return this.predictList(inputArray);
+  } else {
+    return this.predictSingle(inputArray);
   }
-  return this.predictSingle(inputArray);
 };
 
 LocalDeepnet.prototype.predictSingle = function (inputArray) {
@@ -546,19 +547,19 @@ LocalDeepnet.prototype.predictList = function (inputArray) {
   var inputArrayTrees, youts, model, index, len;
   if (typeof this.network.trees !== 'undefined' && this.network.trees != null) {
     inputArrayTrees = pp.treeTransform(inputArray, this.network.trees);
-    youts = [];
-    for (index = 0, len = this.networks.length; index < len; index++) {
-      model = this.networks[index];
-      if (typeof model.trees !== 'undefined' && model.trees != null
-          && model.trees) {
-        // so far, model.tress = false when empty, but just in case
-        youts.push(this.modelPredict(inputArrayTrees, model));
-      } else {
-        youts.push(this.modelPredict(inputArray, model));
-      }
-    }
-    return this.toPrediction(net.sumAndNormalize(youts, this.regression));
   }
+  youts = [];
+  for (index = 0, len = this.networks.length; index < len; index++) {
+    model = this.networks[index];
+    if (typeof model.trees !== 'undefined' && model.trees != null
+        && model.trees) {
+      // so far, model.tress = false when empty, but just in case
+      youts.push(this.modelPredict(inputArrayTrees, model));
+    } else {
+      youts.push(this.modelPredict(inputArray, model));
+    }
+  }
+  return this.toPrediction(net.sumAndNormalize(youts, this.regression));
 }
 
 
@@ -597,7 +598,7 @@ LocalDeepnet.prototype.toPrediction = function (yOut) {
   var prediction, sortedPrediction, distribution, index, len, category;
 
   if (this.regression) {
-    return yOut;
+    return { prediction : yOut };
   }
   prediction = yOut[0];
   if (prediction.constructor != Array) {

--- a/lib/MultiVote.js
+++ b/lib/MultiVote.js
@@ -435,7 +435,6 @@ MultiVote.prototype.combine = function (method, options) {
    *        additional options if threshold is applied.
    * @return {[prediction, combinedConfidence]}
    */
-
   var weight, keys, predictions = this, index = 0, prediction, len, total,
     output = [], distribution = {}, index2, len2;
 
@@ -467,7 +466,8 @@ MultiVote.prototype.combine = function (method, options) {
       }
     }
     if (this.isRegression()) {
-      return weightedSum(this.predictions, weight) + this.boostingOffsets;
+      return { prediction :
+               weightedSum(this.predictions, weight) + this.boostingOffsets };
     } else {
       return this.classificationBoostingCombiner(options);
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bindings",
     "BigML"
   ],
-  "version": "1.18.6",
+  "version": "1.18.7",
   "author": {
     "name": "BigML",
     "email": "info@bigml.com"
@@ -34,7 +34,7 @@
     "winston": "2.4.0"
   },
   "scripts": {
-    "test": "mocha -t 200000"
+    "test": "mocha -t 3500000"
   },
   "devDependencies": {
     "jshint": "^2.9.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "winston": "2.4.0"
   },
   "scripts": {
-    "test": "mocha -t 3500000"
+    "test": "mocha -t 3600000"
   },
   "devDependencies": {
     "jshint": "^2.9.5",

--- a/test/LocalDeepnet-test.js
+++ b/test/LocalDeepnet-test.js
@@ -20,12 +20,60 @@ var assert = require('assert'),
   path = require('path');
 var scriptName = path.basename(__filename);
 
+function beforeFunc(csvPath, deepnetArgs, context) {
+  return function (done) {
+
+    var source = new bigml.Source(),
+        dataset = new bigml.Dataset(),
+        deepnet = new bigml.Deepnet();
+
+    context.cleanUp = [];
+
+    source.create(csvPath, undefined, function (error, data) {
+      assert.equal(data.code, bigml.constants.HTTP_CREATED);
+      context.cleanUp.push([source, data.resource]);
+      dataset.create(data.resource, undefined, function (error, data) {
+        assert.equal(data.code, bigml.constants.HTTP_CREATED);
+        context.cleanUp.push([dataset, data.resource]);
+        deepnet.create(data.resource, deepnetArgs, function (error, data) {
+          assert.equal(data.code, bigml.constants.HTTP_CREATED);
+          context.deepnetId = data.resource;
+          context.cleanUp.push([deepnet, context.deepnetId]);
+          context.deepnetResource = data;
+          deepnet.get(context.deepnetResource, true, 'only_model=true',
+                      function (error, data) {
+                        context.deepnetFinishedResource = data;
+                        done();
+                      });
+        });
+      });
+    });
+  }
+}
+
+function afterFunc(context, done) {
+
+  function deleteOneByOne(resourceList, failedList) {
+    var handler, resourceId;
+    if (resourceList.length == 0) {
+      assert.deepEqual(failedList, []);
+      done();
+      return;
+    }
+    [handler, resourceId] = resourceList.shift();
+    handler.delete(resourceId, function (error, data) {
+      if (error != null && failedList.indexOf(resourceId) == -1) {
+        failedList.push(resourceId);
+      }
+      deleteOneByOne(resourceList, failedList);
+    });
+  }
+  
+  deleteOneByOne(context.cleanUp, []);
+}
+
 describe(scriptName + ': Manage local model objects', function () {
-  var sourceId, source = new bigml.Source(), path = './data/iris.csv',
-    datasetId, dataset = new bigml.Dataset(),
-    args = undefined,
-    deepnetId, deepnet = new bigml.Deepnet(),
-    deepnetResource, deepnetFinishedResource,
+  var context = {},
     localDeepnet, firstPredictionProbability, secondPredictionProbability,
     inputData1 = {},
     inputData2 = {'petal length': 1, 'sepal length': 1, 'petal width': 1,
@@ -33,29 +81,11 @@ describe(scriptName + ': Manage local model objects', function () {
     prediction1 = JSON.parse('{"prediction":"Iris-versicolor","probability":0.46999,"distribution":[{"category":"Iris-setosa","probability":0.4257},{"category":"Iris-versicolor","probability":0.46999},{"category":"Iris-virginica","probability":0.10432}]}'),
     prediction2 = JSON.parse('{"prediction":"Iris-setosa","probability":0.50504,"distribution":[{"category":"Iris-setosa","probability":0.50504},{"category":"Iris-versicolor","probability":0.48348},{"category":"Iris-virginica","probability":0.01149}]}')
 
-  before(function (done) {
-    source.create(path, undefined, function (error, data) {
-      assert.equal(data.code, bigml.constants.HTTP_CREATED);
-      sourceId = data.resource;
-      dataset.create(sourceId, undefined, function (error, data) {
-        assert.equal(data.code, bigml.constants.HTTP_CREATED);
-        datasetId = data.resource;
-        deepnet.create(datasetId, args, function (error, data) {
-          assert.equal(data.code, bigml.constants.HTTP_CREATED);
-          deepnetId = data.resource;
-          deepnetResource = data;
-          deepnet.get(deepnetResource, true, 'only_model=true', function (error, data) {
-            deepnetFinishedResource = data;
-            done();
-          });
-        });
-      });
-    });
-  });
-
+  before(beforeFunc('./data/iris.csv', undefined, context));
+ 
   describe('LocalDeepnet(deepnetId)', function () {
     it('should create a localDeepnet from a deepnet Id', function (done) {
-      localDeepnet = new bigml.LocalDeepnet(deepnetId);
+      localDeepnet = new bigml.LocalDeepnet(context.deepnetId);
       if (localDeepnet.ready) {
         assert.ok(true);
         done();
@@ -92,7 +122,7 @@ describe(scriptName + ': Manage local model objects', function () {
   });
   describe('LocalDeepnet(deepnetResource)', function () {
     it('should create a localDeepnet from a deepnet unfinished resource', function (done) {
-      localDeepnet = new bigml.LocalDeepnet(deepnetResource);
+      localDeepnet = new bigml.LocalDeepnet(context.deepnetResource);
       if (localDeepnet.ready) {
         assert.ok(true);
         done();
@@ -121,7 +151,7 @@ describe(scriptName + ': Manage local model objects', function () {
   });
   describe('LocalDeepnet(deepnetFinishedResource)', function () {
     it('should create a localDeepnet from a model finished resource', function () {
-      localDeepnet = new bigml.LocalDeepnet(deepnetFinishedResource);
+      localDeepnet = new bigml.LocalDeepnet(context.deepnetFinishedResource);
       assert.ok(localDeepnet.ready);
     });
   });
@@ -134,21 +164,104 @@ describe(scriptName + ': Manage local model objects', function () {
     });
   });
   after(function (done) {
-    source.delete(sourceId, function (error, data) {
-      assert.equal(error, null);
-      done();
+    afterFunc(context, done);
+  });
+});
+
+describe(scriptName + ': Local Regression Deepnets with Search', function () {
+  var context = {},
+    localDeepnet,
+    inputData1 = {},
+    inputData2 = {'Midterm': 50, 'Assignment': 19, 'Unknown': 1},
+    prediction1 = JSON.parse('{ "prediction": 66.42764400447102, ' + 
+                             '"unusedFields": ["Unknown"] }')
+    prediction2 = JSON.parse('{ "prediction": -6.74669884503282, ' + 
+                             '"unusedFields": ["Unknown"] }'),
+    prediction3 = JSON.parse('{ "prediction": 38.31076738844381, ' + 
+                             '"unusedFields": ["Unknown"] }');
+
+  before(beforeFunc('./data/grades.csv', 
+                    { search : true,
+                      max_training_time: 120,
+                      number_of_model_candidates: 10 },
+                    context));
+
+  describe('LocalDeepnet(deepnetId)', function () {
+    it('should create a localDeepnet from a deepnet Id', function (done) {
+      localDeepnet = new bigml.LocalDeepnet(context.deepnetId);
+      if (localDeepnet.ready) {
+        assert.ok(true);
+        done();
+      } else {
+        localDeepnet.on('ready', function () {
+          assert.ok(true);
+          done();
+        });
+      }
+    });
+  });
+  describe('#predict(inputData, callback)', function () {
+    it('should predict asynchronously from input data', function (done) {
+      localDeepnet.predict(inputData1, 0, function (error, data) {
+        assert.notEqual(data.prediction, null);
+        done();
+      });
+    });
+  });
+  describe('#predict(inputData)', function () {
+    it('should predict synchronously from input data', function () {
+      var prediction = localDeepnet.predict(inputData2);
+      assert.notEqual(prediction.prediction, null);
+      secondPredictionProbability = prediction.probability;
+    });
+  });
+  describe('#predict(inputData)', function () {
+    it('should predict synchronously from input data keyed by field id',
+       function () {
+      var prediction = localDeepnet.predict({'000000': 1, '000001': 1, '000002': 1, '000003': 1});
+      assert.notEqual(prediction.prediction, null);
+    });
+  });
+  describe('LocalDeepnet(deepnetResource)', function () {
+    it('should create a localDeepnet from a deepnet unfinished resource', function (done) {
+      localDeepnet = new bigml.LocalDeepnet(context.deepnetResource);
+      if (localDeepnet.ready) {
+        assert.ok(true);
+        done();
+      } else {
+        localDeepnet.on('ready', function () {assert.ok(true);
+          done();
+          });
+      }
+    });
+  });
+  describe('#predict(inputData, callback)', function () {
+    it('should predict asynchronously from input data', function (done) {
+      localDeepnet.predict(inputData1, true, function (error, data) {
+        assert.notEqual(data.prediction, null);
+        done();
+      });
+    });
+  });
+  describe('#predict(inputData, callback)', function () {
+    it('should predict asynchronously from input data', function (done) {
+      localDeepnet.predict(inputData2, true, function (error, data) {
+        assert.equal(JSON.stringify(data.unusedFields), 
+                     JSON.stringify(prediction2.unusedFields));
+        done();
+      });
+    });
+  });
+  describe('#predict(inputData, callback)', function () {
+    it('should predict asynchronously from input data', function (done) {
+      localDeepnet.predict(inputData2, true, function (error, data) {
+        assert.equal(JSON.stringify(data.unusedFields), 
+                     JSON.stringify(prediction2.unusedFields));
+        done();
+      });
     });
   });
   after(function (done) {
-    dataset.delete(datasetId, function (error, data) {
-      assert.equal(error, null);
-      done();
-    });
-  });
-  after(function (done) {
-    deepnet.delete(deepnetId, function (error, data) {
-      assert.equal(error, null);
-      done();
-    });
+    afterFunc(context, done);
   });
 });

--- a/test/LocalEnsemble-test-boosting-regression.js
+++ b/test/LocalEnsemble-test-boosting-regression.js
@@ -89,14 +89,14 @@ describe(scriptName + ': Manage local ensemble objects', function () {
   describe('#predict(inputData, method, callback)', function () {
     it('should predict asynchronously from input data', function (done) {
       localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(truncate(data, decimals), reference);
+        assert.equal(truncate(data.prediction, decimals), reference);
         done();
       });
     });
   });
   describe('#predict(inputData, method)', function () {
     it('should predict synchronously from input data', function () {
-      var result = localEnsemble.predict(inputData, method);
+      var result = localEnsemble.predict(inputData, method).prediction;
       assert.equal(truncate(result, decimals), reference);
     });
   });
@@ -116,7 +116,7 @@ describe(scriptName + ': Manage local ensemble objects', function () {
   describe('#predict(inputData, method, callback)', function () {
     it('should predict asynchronously from input data', function (done) {
       localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(truncate(data, decimals), reference);
+        assert.equal(truncate(data.prediction, decimals), reference);
         done();
       });
     });
@@ -137,7 +137,7 @@ describe(scriptName + ': Manage local ensemble objects', function () {
   describe('#predict(inputData, method)', function () {
     it('should predict asynchronously from input data', function (done) {
       localEnsemble.predict(inputData, method, function (error, data) {
-        assert.equal(truncate(data, decimals), reference);
+        assert.equal(truncate(data.prediction, decimals), reference);
         done();
       });
     });


### PR DESCRIPTION
I also added a unit test for local deepenet prediction when using the search = true option -- which was causing our recent issues. The unit test can only check that a prediction is actually given (no empty prediction) and that the list of unused fields matches the expected one. No checks on the prediction value can be done since the prediction changes each time due to (I suspect) the search algorithm. Still, the checks that are done are enough to cover any regressions.