### PR TITLE
fix for corner case network failure on getaddrinfo EAI_AGAIN

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -158,7 +158,7 @@ Resource.prototype.get = function (resource, finished, query, cb) {
         result = utils.makeEmptyResult('resource',
                                        code,
                                        'The resource couldn\'t be retrieved');
-      if (error) {
+      if (error || !response) {
         logger.error('Request processing error: ' + error);
         result.error.status.message += ': ' + error;
         info = '';


### PR DESCRIPTION
This PR fixes a corner-case failure due to failing DNS resolution giving the following error traces:

```
error:  method=GET, resource=dataset/5e66639e7811dd03f500bd47, resourceType=dataset, endpoint=/5e66639e7811dd03f500bd47, query=undefined, store=true
error:  retries=10, wait=1000, retriesLeft=9
error: Remote request failed: Error: getaddrinfo EAI_AGAIN bigml.io:443 Retrying in 1 s. 9 retries left.
```

In spite of correctly logging the failure, the bindings try to access the (undefined) `response` object, causing a crash.

The fix is trivial, based on this stack trace:

```
error: uncaughtException: Cannot read property 'statusCode' of undefined date=Mon Mar 09 2020 15:41:35 GMT+0000 (UTC), pid=8514, uid=0, gid=0, cwd=/usr/local/carnac, execPath=/usr/bin/node, version=v8.10.0, argv=[/usr/bin/node, /usr/local/carnac/src/master.ts, carnac], rss=137678848, heapTotal=76525568, heapUsed=71756744, external=450417, loadavg=[0.51611328125, 0.2255859375, 0.09521484375], uptime=685637, trace=[column=29, file=/usr/local/carnac/node_modules/bigml/lib/Resource.js, function=processResponse, line=171, method=null, native=false, column=12, file=/usr/local/carnac/node_modules/bigml/lib/BigML.js, function=Request._callback, line=218, method=_callback, native=false, column=22, file=/usr/local/carnac/node_modules/bigml/node_modules/request/request.js, function=self.callback, line=186, method=callback, native=false, column=13, file=events.js, function=emitOne, line=116, method=null, native=false, column=7, file=events.js, function=Request.emit, line=211, method=emit, native=false, column=8, file=/usr/local/carnac/node_modules/bigml/node_modules/request/request.js, function=Request.onRequestError, line=878, method=onRequestError, native=false, column=13, file=events.js, function=emitOne, line=116, method=null, native=false, column=7, file=events.js, function=ClientRequest.emit, line=211, method=emit, native=false, column=9, file=_http_client.js, function=TLSSocket.socketErrorListener, line=387, method=socketErrorListener, native=false, column=13, file=events.js, function=emitOne, line=116, method=null, native=false, column=7, file=events.js, function=TLSSocket.emit, line=211, method=emit, native=false, column=8, file=internal/streams/destroy.js, function=emitErrorNT, line=64, method=null, native=false, column=11, file=internal/process/next_tick.js, function=_combinedTickCallback, line=138, method=null, native=false, column=9, file=internal/process/next_tick.js, function=process._tickDomainCallback, line=218, method=_tickDomainCallback, native=false], 

stack=[TypeError: Cannot read property 'statusCode' of undefined,     at processResponse (/usr/local/carnac/node_modules/bigml/lib/Resource.js:171:29),     at Request._callback (/usr/local/carnac/node_modules/bigml/lib/BigML.js:218:12),     at self.callback (/usr/local/carnac/node_modules/bigml/node_modules/request/request.js:186:22),     at emitOne (events.js:116:13),     at Request.emit (events.js:211:7),     at Request.onRequestError (/usr/local/carnac/node_modules/bigml/node_modules/request/request.js:878:8),     at emitOne (events.js:116:13),     at ClientRequest.emit (events.js:211:7),     at TLSSocket.socketErrorListener (_http_client.js:387:9),     at emitOne (events.js:116:13),     at TLSSocket.emit (events.js:211:7),     at emitErrorNT (internal/streams/destroy.js:64:8),     at _combinedTickCallback (internal/process/next_tick.js:138:11),     at process._tickDomainCallback (internal/process/next_tick.js:218:9)]
```

